### PR TITLE
Fix: 소비 수정

### DIFF
--- a/backend/src/main/java/com/gdsc/backend/config/SessionConfig.java
+++ b/backend/src/main/java/com/gdsc/backend/config/SessionConfig.java
@@ -1,0 +1,46 @@
+package com.gdsc.backend.config;
+
+import com.gdsc.backend.service.LoginService;
+import com.gdsc.backend.service.UserSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.annotation.WebListener;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+
+import static com.gdsc.backend.service.UserSession.USER_SESSION_KEY;
+
+@WebListener
+public class SessionConfig implements HttpSessionListener {
+    private static final Logger log = LoggerFactory.getLogger(SessionConfig.class);
+
+    private final LoginService loginService;
+
+    public SessionConfig(final LoginService loginService) {
+        this.loginService = loginService;
+    }
+
+    @Override
+    public void sessionCreated(HttpSessionEvent se) {
+        HttpSession httpSession = se.getSession();
+        log.info("Session Created, session ID : {}, time-out : {}",
+                httpSession.getId(), httpSession.getMaxInactiveInterval());
+    }
+
+    @Override
+    public void sessionDestroyed(HttpSessionEvent se) {
+        HttpSession httpSession = se.getSession();
+        log.info("Session Destroyed, session ID : {}, user : {}",
+                httpSession.getId(), httpSession.getAttribute(USER_SESSION_KEY));
+        logout(httpSession);
+    }
+
+    private void logout(HttpSession httpSession) {
+        UserSession userSession = (UserSession) httpSession.getAttribute(USER_SESSION_KEY);
+        if (userSession != null) {
+            loginService.logout(userSession.getUserId());
+        }
+    }
+}

--- a/backend/src/main/java/com/gdsc/backend/controller/ConsumptionController.java
+++ b/backend/src/main/java/com/gdsc/backend/controller/ConsumptionController.java
@@ -1,9 +1,11 @@
 package com.gdsc.backend.controller;
 
+import com.gdsc.backend.annotation.LoginUser;
 import com.gdsc.backend.domain.Consumption;
 import com.gdsc.backend.dto.request.ConsumptionRequest;
 import com.gdsc.backend.dto.response.ConsumptionResponse;
 import com.gdsc.backend.service.ConsumptionManagementService;
+import com.gdsc.backend.service.UserSession;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -17,6 +19,8 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +29,7 @@ import java.util.Optional;
 @RequestMapping("/api/consumptions")
 public class ConsumptionController {
 
-    private ConsumptionManagementService consumptionManagementService;
+    private final ConsumptionManagementService consumptionManagementService;
 
     public ConsumptionController(final ConsumptionManagementService consumptionManagementService){
         this.consumptionManagementService=consumptionManagementService;
@@ -38,8 +42,8 @@ public class ConsumptionController {
             }
     )
     @PostMapping
-    public ResponseEntity<Consumption> createConsumption(@RequestBody ConsumptionRequest consumptionRequest){
-        Consumption creation= consumptionManagementService.save(consumptionRequest);
+    public ResponseEntity<Consumption> createConsumption(@RequestBody ConsumptionRequest consumptionRequest, HttpSession httpSession){
+        Consumption creation= consumptionManagementService.save(consumptionRequest,httpSession.getAttribute("user_id").toString());
         return new ResponseEntity<Consumption>(creation, HttpStatus.CREATED);
     }
 
@@ -63,8 +67,8 @@ public class ConsumptionController {
     )
     @GetMapping("/{index}")
     public ResponseEntity<ConsumptionResponse> showConsumptionByIndex(@Parameter(name = "index", in = ParameterIn.PATH, description = "조회할 소비의 인덱스")
-                                                                          @PathVariable("index")Long index){
-        ConsumptionResponse consumptionResponse= consumptionManagementService.showByIndex(index);
+                                                                          @PathVariable("index")Long index,HttpSession httpSession){
+        ConsumptionResponse consumptionResponse= consumptionManagementService.showByIndex(index,httpSession.getAttribute("user_id").toString());
         return new ResponseEntity<ConsumptionResponse>(consumptionResponse, HttpStatus.OK);
     }
 

--- a/backend/src/main/java/com/gdsc/backend/domain/Consumption.java
+++ b/backend/src/main/java/com/gdsc/backend/domain/Consumption.java
@@ -51,18 +51,19 @@ public class Consumption {
     @Enumerated(EnumType.STRING)
     private UseType useType;
 
-    /*@ManyToOne
+    @ManyToOne
     @JoinColumn(name = "userId",referencedColumnName = "userId",nullable = false)
-    private User user;*/
+    private User user;
 
     @Builder
-    public Consumption(String content, int cost, DwType dwType, PayType payType, UseType useType,int consumptionDatetime){
+    public Consumption(String content, int cost, DwType dwType, PayType payType, UseType useType,int consumptionDatetime,User user){
         this.content = content;
         this.cost =cost;
         this.dwType = dwType;
         this.payType=payType;
         this.useType = useType;
         this.consumptionDatetime=consumptionDatetime;
+        this.user=user;
     }
 
     public void update(ConsumptionRequest consumptionRequest){

--- a/backend/src/main/java/com/gdsc/backend/exception/ConsumptionGetFailException.java
+++ b/backend/src/main/java/com/gdsc/backend/exception/ConsumptionGetFailException.java
@@ -1,0 +1,14 @@
+package com.gdsc.backend.exception;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConsumptionGetFailException extends RuntimeException{
+    public static final String CONSUMPTION_GET_FAIL_MESSAGE = "소비 조회 실패 : ";
+    private static final Logger log = LoggerFactory.getLogger(ConsumptionGetFailException.class);
+
+    public ConsumptionGetFailException(String message) {
+        super(CONSUMPTION_GET_FAIL_MESSAGE + message);
+        log.error(CONSUMPTION_GET_FAIL_MESSAGE + message);
+    }
+}

--- a/backend/src/main/java/com/gdsc/backend/repository/ConsumptionRepository.java
+++ b/backend/src/main/java/com/gdsc/backend/repository/ConsumptionRepository.java
@@ -1,10 +1,13 @@
 package com.gdsc.backend.repository;
 
 import com.gdsc.backend.domain.Consumption;
+import com.gdsc.backend.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ConsumptionRepository extends JpaRepository<Consumption,Long> {
     public Consumption findConsumptionByConsumptionIndex(Long index);
+
+    public Consumption findConsumptionByConsumptionIndexAndAndUser(Long index, User user);
 }

--- a/backend/src/main/java/com/gdsc/backend/service/ConsumptionManagementService.java
+++ b/backend/src/main/java/com/gdsc/backend/service/ConsumptionManagementService.java
@@ -1,24 +1,33 @@
 package com.gdsc.backend.service;
 
 import com.gdsc.backend.domain.Consumption;
+import com.gdsc.backend.domain.User;
 import com.gdsc.backend.dto.request.ConsumptionRequest;
 import com.gdsc.backend.dto.response.ConsumptionResponse;
+import com.gdsc.backend.exception.ConsumptionGetFailException;
+import com.gdsc.backend.exception.LoginFailException;
 import com.gdsc.backend.repository.ConsumptionRepository;
+import com.gdsc.backend.repository.UserRepository;
+import org.slf4j.Logger;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
 public class ConsumptionManagementService {
 
-    private ConsumptionRepository consumptionRepository;
+    private final ConsumptionRepository consumptionRepository;
+    private final UserRepository userRepository;
 
-    public ConsumptionManagementService(final ConsumptionRepository consumptionRepository){
+    public ConsumptionManagementService(final ConsumptionRepository consumptionRepository,final UserRepository userRepository){
         this.consumptionRepository=consumptionRepository;
+        this.userRepository=userRepository;
     }
 
-    public Consumption save(final ConsumptionRequest consumptionRequest){
+    @Transactional
+    public Consumption save(final ConsumptionRequest consumptionRequest,final String userId){
         return consumptionRepository.save(Consumption.builder()
                 .content(consumptionRequest.getContent())
                 .cost(consumptionRequest.getCost())
@@ -26,6 +35,7 @@ public class ConsumptionManagementService {
                 .payType(consumptionRequest.getPayType())
                 .dwType(consumptionRequest.getDwType())
                 .consumptionDatetime(consumptionRequest.getConsumptionDatetime())
+                .user(userRepository.findByUserId(userId))
                 .build());
     }
 
@@ -41,8 +51,14 @@ public class ConsumptionManagementService {
         return consumptionRepository.findAll(pageable).getContent();
     }
 
-    public ConsumptionResponse showByIndex(Long index){
-        Consumption consumption=consumptionRepository.findConsumptionByConsumptionIndex(index);
+    public ConsumptionResponse showByIndex(Long index, final String userId) {
+        Consumption consumption;
+        try {
+            User user = userRepository.findByUserId(userId);
+            consumption = consumptionRepository.findConsumptionByConsumptionIndexAndAndUser(index, user);
+        } catch (Exception e) {
+            throw new ConsumptionGetFailException(e.getMessage());
+        }
         return ConsumptionResponse.from(consumption);
     }
 

--- a/backend/src/main/java/com/gdsc/backend/service/LoginInterceptor.java
+++ b/backend/src/main/java/com/gdsc/backend/service/LoginInterceptor.java
@@ -1,0 +1,24 @@
+package com.gdsc.backend.service;
+
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import static com.gdsc.backend.service.UserSession.USER_SESSION_KEY;
+
+public class LoginInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) throws Exception {
+        HttpSession session = request.getSession();
+
+        if (session.getAttribute(USER_SESSION_KEY) == null) {
+            response.sendRedirect("/api/login");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/backend/src/main/java/com/gdsc/backend/service/UserSession.java
+++ b/backend/src/main/java/com/gdsc/backend/service/UserSession.java
@@ -14,13 +14,13 @@ import javax.servlet.http.HttpSessionBindingListener;
 public class UserSession implements HttpSessionBindingListener {
     public static final String USER_SESSION_KEY = "loginUser";
 
-    private String usreId;
+    private String userId;
     private String userName;
 
     @Builder
     private UserSession(String userId,String userName) {
         this.userName=userName;
-        this.usreId=userId;
+        this.userId=userId;
     }
 
     public static UserSession from(User user) {


### PR DESCRIPTION
### What is this PR? 🔍
- 소비 생성(등록)기능에서  세션을 이용하여  소비를 생성할 때 현재 로그인한 유저의 아이디를 저장
-  소비를 조회할 때 로그인한 유저가 등록한 소비만 볼 수 있도록 showConsumptionByIndex함수 수정

### 추가 수정 필요
- 전체 소비 조회에서 로그인한 유저가 등록한 소비들만 볼 수 있도록 showConsumptionList함수 수정
- 세션을 이용하여 로그인 유저의 아이디를 저장하는 방식을 수정
-
### Issue
https://github.com/GDSC-DEU/2022-SolutionChallenge-UsNe/issues/20